### PR TITLE
Runtime option

### DIFF
--- a/index.html
+++ b/index.html
@@ -551,13 +551,16 @@
         lambda to assume the default role instead of the role designed to
         specifically work with DynamoDB.</p>
 
-        <p>The <code>--methods</code> flag adds HTTP methods to the endpoint ,
+        <p>The <code>--methods</code> flag adds HTTP methods to the endpoint,
         and <code>--rmMethods</code> allows for the removal of methods
         attached to the
         endpoint.</p>
 
         <p>The <code>--addEndpoint</code> flag adds an endpoint to a lambda
         that is not currently integrated with one.</p>
+
+        <p>The <code>--runtime</code> flag updates the runtime a lambda uses,
+        however, only to an actively-supported Node runtime.</p>
 
         <code class="command">create</code>
         <p>The <code>create</code> command creates a local file or directory


### PR DESCRIPTION
Following [PR1](https://github.com/bam-lambda/bam/pull/181) and [PR2](https://github.com/bam-lambda/bam/pull/182), this PR updates the description of the `redeploy` command in the Commands section of the whitepaper to include the `runtime` flag.

Note: I made a commit directly on master to update the supported Node version mentioned at the end of section 2.4.1 as it was only a few characters.